### PR TITLE
Switch Ethereum transaction processing from ChainJS to EIP-1559 format via Web3

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,12 +20,17 @@ const envs = {
   ethereumApprovalContractAddress: process.env.ETHEREUM_APPROVAL_CONTRACT_ADDRESS
 }
 
-const redisClient = redis.createClient({
-  url: envs.redisUrl,
-  tls: {
+const redisClientOptions = {
+  url: envs.redisUrl
+}
+
+if (envs.redisUrl.includes("rediss://")) {
+  redisClientOptions.tls = {
     rejectUnauthorized: false
   }
-})
+}
+
+const redisClient = redis.createClient(redisClientOptions)
 
 async function initialize() {
   if (!hwUtils.checkAllVariablesAreSet(envs)) {

--- a/lib/blockchains/EthereumBlockchain.js
+++ b/lib/blockchains/EthereumBlockchain.js
@@ -1,6 +1,9 @@
 const chainjs = require("@open-rights-exchange/chainjs")
 const BigNumber = require('bignumber.js')
 const HotWallet = require("../HotWallet").HotWallet
+const Web3 = require('web3')
+const Common = require('@ethereumjs/common')
+const FeeMarketEIP1559Transaction = require('@ethereumjs/tx').FeeMarketEIP1559Transaction
 
 class EthereumBlockchain {
   constructor(envs) {
@@ -239,26 +242,58 @@ class EthereumBlockchain {
     return new HotWallet(this.blockchainNetwork, createAccount.accountName, createAccount.generatedKeys)
   }
 
+  async sendEIP1559Tx(txn, hotWallet) {
+    const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
+
+    txn.gasLimit = await web3.eth.estimateGas(txn)
+    txn.maxPriorityFeePerGas = 1
+    txn.maxFeePerGas = 255
+    txn.nonce = await web3.eth.getTransactionCount(hotWallet.address, 'pending')
+
+    const common = new Common.default({ chain: Common.Chain.Rinkeby, hardfork: Common.Hardfork.London })
+    const tx = FeeMarketEIP1559Transaction.fromTxData(txn, { common })
+    const signedTx = tx.sign(Buffer.from(hotWallet.privateKey.slice(2), 'hex'))
+    const serializedTx = signedTx.serialize().toString('hex')
+    
+    return await new Promise(async (resolve) => {
+      await web3.eth.sendSignedTransaction('0x' + serializedTx)
+        .once('transactionHash', txHash => {
+          console.log('transactionHash:', txHash)
+        })
+        .once('confirmation', (confirmationNumber, receipt) => {
+          console.log('confirmations:', confirmationNumber, receipt)
+          resolve({ transactionId: receipt.txHash })
+        })
+        .once('error:', error => {
+          console.error(error)
+          resolve({ valid: false, markAs: "failed", error: error })
+        })
+    })
+  }
+
   async approveContractTransactions(hotWallet, contractAddress, approvalContractAddress) {
     await this.connect()
 
     const txn = this.approveTxObject(hotWallet.address, contractAddress, approvalContractAddress)
     txn.data = chainjs.HelpersEthereum.generateDataFromContractAction(txn.contract)
 
-    const chainTransaction = await this.chain.new.Transaction()
+    // Web3 + EIP-1559:
+    return await this.sendEIP1559Tx(txn, hotWallet)
+    
+    // const chainTransaction = await this.chain.new.Transaction()
 
-    try {
-      await chainTransaction.setFromRaw(txn)
-      await chainTransaction.prepareToBeSigned()
-      await chainTransaction.validate()
-      await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
-      const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
-      console.log(`Approve contract transaction has successfully sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
-      return tx_result
-    } catch (err) {
-      console.error(err)
-      return { valid: false, error: err.message }
-    }
+    // try {
+    //   await chainTransaction.setFromRaw(txn)
+    //   await chainTransaction.prepareToBeSigned()
+    //   await chainTransaction.validate()
+    //   await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
+    //   const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
+    //   console.log(`Approve contract transaction has successfully sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
+    //   return tx_result
+    // } catch (err) {
+    //   console.error(err)
+    //   return { valid: false, error: err.message }
+    // }
   }
 
   async getEthBalance(hotWalletAddress) {
@@ -344,30 +379,33 @@ class EthereumBlockchain {
     const txn = JSON.parse(transaction.txRaw || "{}")
     txn.data = chainjs.HelpersEthereum.generateDataFromContractAction(txn.contract)
 
-    const chainTransaction = await this.chain.new.Transaction()
+    // Web3 + EIP-1559:
+    return await this.sendEIP1559Tx(txn, hotWallet)
 
-    try {
-      await chainTransaction.setFromRaw(txn)
-      const ethFee = await chainTransaction.getSuggestedFee(chainjs.Models.TxExecutionPriority.Fast)
+    // const chainTransaction = await this.chain.new.Transaction()
 
-      // validate enough gas
-      if (new BigNumber(ethFee).isGreaterThan(this.getEthBalance)) {
-        const errorMessage = `The Hot Wallet has insufficient gas. Please top up the ${hotWallet.address}`
-        console.error(errorMessage)
-        return { valid: false, markAs: "cancelled", error: errorMessage}
-      }
+    // try {
+    //   await chainTransaction.setFromRaw(txn)
+    //   const ethFee = await chainTransaction.getSuggestedFee(chainjs.Models.TxExecutionPriority.Fast)
 
-      await chainTransaction.setDesiredFee(ethFee)
-      await chainTransaction.prepareToBeSigned()
-      await chainTransaction.validate()
-      await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
-      const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
-      console.log(`Transaction has successfully signed and sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
-      return tx_result
-    } catch (err) {
-      console.error(err)
-      return { valid: false, markAs: "failed", error: err.message }
-    }
+    //   // validate enough gas
+    //   if (new BigNumber(ethFee).isGreaterThan(this.getEthBalance)) {
+    //     const errorMessage = `The Hot Wallet has insufficient gas. Please top up the ${hotWallet.address}`
+    //     console.error(errorMessage)
+    //     return { valid: false, markAs: "cancelled", error: errorMessage}
+    //   }
+
+    //   await chainTransaction.setDesiredFee(ethFee)
+    //   await chainTransaction.prepareToBeSigned()
+    //   await chainTransaction.validate()
+    //   await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
+    //   const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
+    //   console.log(`Transaction has successfully signed and sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
+    //   return tx_result
+    // } catch (err) {
+    //   console.error(err)
+    //   return { valid: false, markAs: "failed", error: err.message }
+    // }
   }
 
   async sendWithdrawalCoinsTransaction(coinAddress, totalAmount, hotWallet) {

--- a/lib/blockchains/EthereumBlockchain.js
+++ b/lib/blockchains/EthereumBlockchain.js
@@ -17,6 +17,19 @@ class EthereumBlockchain {
     this.tokenBalances = {}
   }
 
+  get chainName() {
+    switch (this.blockchainNetwork) {
+      case 'ethereum':
+        return 'mainnet'
+      case 'ethereum_ropsten':
+        return 'ropsten'
+      case 'ethereum_rinkeby':
+        return 'rinkeby'
+      default:
+        console.error("Unknown or unsupported network: ", this.blockchainNetwork)
+    }
+  }
+
   mainnetEndpoints() {
     return [
       {
@@ -243,14 +256,14 @@ class EthereumBlockchain {
   }
 
   async sendEIP1559Tx(txn, hotWallet) {
-    const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
+    const web3 = new Web3(new Web3.providers.HttpProvider(`https://${this.chainName}.infura.io/v3/${this.envs.infuraProjectId}`))
 
     txn.gasLimit = await web3.eth.estimateGas(txn)
     txn.maxPriorityFeePerGas = web3.utils.toHex(web3.utils.toWei( '2' , 'gwei' ))
     txn.maxFeePerGas =  web3.utils.toHex(web3.utils.toWei( '3' , 'gwei' ))
     txn.nonce = await web3.eth.getTransactionCount(hotWallet.address, 'pending')
 
-    const common = new Common.default({ chain : 'rinkeby', hardfork : 'london' })
+    const common = new Common.default({ chain : this.chainName, hardfork : 'london' })
     const tx = FeeMarketEIP1559Transaction.fromTxData(txn, { common })
     const signedTx = tx.sign(Buffer.from(hotWallet.privateKey.slice(2), 'hex'))
     const serializedTx = signedTx.serialize().toString('hex')
@@ -283,8 +296,6 @@ class EthereumBlockchain {
   }
 
   async getEthBalance(hotWalletAddress) {
-    if (hotWalletAddress in this.ethBalances) { return this.ethBalances[hotWalletAddress] }
-
     await this.connect()
     const blockchainBalance = await this.chain.fetchBalance(hotWalletAddress, chainjs.HelpersEthereum.toEthereumSymbol('eth'))
     this.ethBalances[hotWalletAddress] = new BigNumber(blockchainBalance.balance || 0)
@@ -304,8 +315,6 @@ class EthereumBlockchain {
   }
 
   async getTokenBalance(hotWalletAddress) {
-    if (hotWalletAddress in this.tokenBalances) { return this.tokenBalances[hotWalletAddress] }
-
     await this.connect()
     // Chainjs version does not work for some reason so I implemented custom check using web3
     // const tokenBalance = await this.chain.fetchBalance(hotWalletAddress, chainjs.HelpersEthereum.toEthereumSymbol(this.envs.ethereumTokenSymbol), this.envs.ethereumContractAddress)
@@ -411,7 +420,7 @@ class EthereumBlockchain {
       const coinBalance = await this.getEthBalance(hotWallet.address)
       
       if (coinBalance.isGreaterThan(new BigNumber(0.001))) {
-        const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
+        const web3 = new Web3(new Web3.providers.HttpProvider(`https://${this.chainName}.infura.io/v3/${this.envs.infuraProjectId}`))
         const block = await web3.eth.getBlock("pending")
         const baseFee = parseInt(block.baseFeePerGas) * 21000
         const txFee = await web3.eth.getGasPrice() * 21000

--- a/lib/blockchains/EthereumBlockchain.js
+++ b/lib/blockchains/EthereumBlockchain.js
@@ -243,14 +243,14 @@ class EthereumBlockchain {
   }
 
   async sendEIP1559Tx(txn, hotWallet) {
-    const web3 = new Web3(new Web3.providers.HttpProvider(`https://ropsten.infura.io/v3/${this.envs.infuraProjectId}`))
+    const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
 
     txn.gasLimit = await web3.eth.estimateGas(txn)
     txn.maxPriorityFeePerGas = web3.utils.toHex(web3.utils.toWei( '2' , 'gwei' ))
     txn.maxFeePerGas =  web3.utils.toHex(web3.utils.toWei( '3' , 'gwei' ))
     txn.nonce = await web3.eth.getTransactionCount(hotWallet.address, 'pending')
 
-    const common = new Common.default({ chain : 'ropsten', hardfork : 'london' })
+    const common = new Common.default({ chain : 'rinkeby', hardfork : 'london' })
     const tx = FeeMarketEIP1559Transaction.fromTxData(txn, { common })
     const signedTx = tx.sign(Buffer.from(hotWallet.privateKey.slice(2), 'hex'))
     const serializedTx = signedTx.serialize().toString('hex')
@@ -279,23 +279,7 @@ class EthereumBlockchain {
     const txn = this.approveTxObject(hotWallet.address, contractAddress, approvalContractAddress)
     txn.data = chainjs.HelpersEthereum.generateDataFromContractAction(txn.contract)
 
-    // Web3 + EIP-1559:
     return await this.sendEIP1559Tx(txn, hotWallet)
-    
-    // const chainTransaction = await this.chain.new.Transaction()
-
-    // try {
-    //   await chainTransaction.setFromRaw(txn)
-    //   await chainTransaction.prepareToBeSigned()
-    //   await chainTransaction.validate()
-    //   await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
-    //   const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
-    //   console.log(`Approve contract transaction has successfully sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
-    //   return tx_result
-    // } catch (err) {
-    //   console.error(err)
-    //   return { valid: false, error: err.message }
-    // }
   }
 
   async getEthBalance(hotWalletAddress) {
@@ -379,72 +363,22 @@ class EthereumBlockchain {
     await this.connect()
 
     const txn = JSON.parse(transaction.txRaw || "{}")
-    txn.data = chainjs.HelpersEthereum.generateDataFromContractAction(txn.contract)
 
-    // Web3 + EIP-1559:
-    return await this.sendEIP1559Tx(txn, hotWallet)
-
-    // const chainTransaction = await this.chain.new.Transaction()
-
-    // try {
-    //   await chainTransaction.setFromRaw(txn)
-    //   const ethFee = await chainTransaction.getSuggestedFee(chainjs.Models.TxExecutionPriority.Fast)
-
-    //   // validate enough gas
-    //   if (new BigNumber(ethFee).isGreaterThan(this.getEthBalance)) {
-    //     const errorMessage = `The Hot Wallet has insufficient gas. Please top up the ${hotWallet.address}`
-    //     console.error(errorMessage)
-    //     return { valid: false, markAs: "cancelled", error: errorMessage}
-    //   }
-
-    //   await chainTransaction.setDesiredFee(ethFee)
-    //   await chainTransaction.prepareToBeSigned()
-    //   await chainTransaction.validate()
-    //   await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
-    //   const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After001)
-    //   console.log(`Transaction has successfully signed and sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
-    //   return tx_result
-    // } catch (err) {
-    //   console.error(err)
-    //   return { valid: false, markAs: "failed", error: err.message }
-    // }
-  }
-
-  async sendWithdrawalCoinsTransaction(coinAddress, totalAmount, hotWallet) {
-    const txToGetFee = await this.chain.new.Transaction()
-    const chainTransaction = await this.chain.new.Transaction()
-
-    try {
-      // To calculate fee let's add tx with the full amount
-      const txValues = { toAccountName: coinAddress, amount: totalAmount.toString(), symbol: 'ether' }
-      txToGetFee.actions = [await this.chain.composeAction(chainjs.Models.ChainActionType.ValueTransfer, txValues)]
-
-      const ethFee = await txToGetFee.getSuggestedFee(chainjs.Models.TxExecutionPriority.Fast)
-      const amountToTransfer = totalAmount.minus(new BigNumber(ethFee)).minus(new BigNumber(0.0001))
-      console.log(`Sending ${amountToTransfer.toString()} ETH to ${coinAddress}`)
-
-      // Set tx with updated amount
-      txValues.amount = amountToTransfer.toString()
-      chainTransaction.actions = [await this.chain.composeAction(chainjs.Models.ChainActionType.ValueTransfer, txValues)]
-
-      await chainTransaction.setDesiredFee(ethFee)
-      await chainTransaction.prepareToBeSigned()
-      await chainTransaction.validate()
-      await chainTransaction.sign([chainjs.HelpersEthereum.toEthereumPrivateKey(hotWallet.privateKey)])
-      const tx_result = await chainTransaction.send(chainjs.Models.ConfirmType.After010)
-      console.log(`Transaction has successfully signed and sent by ${hotWallet.address} to blockchain tx hash: ${tx_result.transactionId}`)
-      return tx_result
-    } catch (err) {
-      console.error(err)
-      return { valid: false, markAs: "failed", error: err.message }
+    if (txn.contract) {
+      txn.data = chainjs.HelpersEthereum.generateDataFromContractAction(txn.contract)
     }
+
+    return await this.sendEIP1559Tx(txn, hotWallet)
   }
 
   async disableWallet(withdrawalAddresses, hotWallet) {
     console.log("Robo wallet is going to be disabled...")
+    
     const result = { tokensWithdrawalTx: {}, coinsWithdrawalTx: {} }
+    
     if (withdrawalAddresses.tokenAddress) {
       const tokenBalance = await this.getTokenBalance(hotWallet.address)
+      
       if (tokenBalance.balanceInBaseUnit.isGreaterThan(new BigNumber(0))) {
         let contractAddress = this.envs.ethereumContractAddress.toString()
 
@@ -455,10 +389,9 @@ class EthereumBlockchain {
 
         const tokensAmount = tokenBalance.balanceInBaseUnit.toString()
         const txObject = this.withdrawTokensTx(hotWallet.address, contractAddress, withdrawalAddresses.tokenAddress, tokensAmount)
-        console.log(`Sending ${tokensAmount} tokens to ${withdrawalAddresses.tokenAddress}`);
+        console.log(`Sending ${tokensAmount} tokens to ${withdrawalAddresses.tokenAddress}`)
 
         const tx = await this.sendTransaction(txObject, hotWallet)
-        // const tx = { transactionId: 'fake token tx' }
 
         if (typeof tx.valid == 'undefined' || tx.valid) {
           const msg = `Successfully sent Tx id: ${tx.transactionId}`
@@ -476,9 +409,17 @@ class EthereumBlockchain {
 
     if (withdrawalAddresses.coinAddress && result.tokensWithdrawalTx.status !== "failed") {
       const coinBalance = await this.getEthBalance(hotWallet.address)
+      
       if (coinBalance.isGreaterThan(new BigNumber(0.001))) {
-        const tx = await this.sendWithdrawalCoinsTransaction(withdrawalAddresses.coinAddress, coinBalance, hotWallet)
-        // const tx = { valid: false, transactionId: 'fake eth tx' }
+        const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
+        const block = await web3.eth.getBlock("pending")
+        const baseFee = parseInt(block.baseFeePerGas) * 21000
+        const txFee = await web3.eth.getGasPrice() * 21000
+        const coinsAmount = web3.utils.toWei(coinBalance.minus(new BigNumber(0.0002)).toString(), 'ether') - txFee - baseFee
+        const txObject = this.withdrawCoinsTx(hotWallet.address, withdrawalAddresses.coinAddress, coinsAmount)
+
+        console.log(`Sending ${coinsAmount} coins to ${withdrawalAddresses.coinAddress}`)
+        const tx = await this.sendTransaction(txObject, hotWallet)
 
         if (typeof tx.valid == 'undefined' || tx.valid) {
           const msg = `Successfully sent Tx id: ${tx.transactionId}`
@@ -489,9 +430,8 @@ class EthereumBlockchain {
           console.error(msg)
           result.coinsWithdrawalTx = { status: "failed", txHash: null, message: msg }
         }
-
       } else {
-        result.coinsWithdrawalTx = { status: "skipped", txHash: null, message: "ETH balance is zero, transaction skipped" }
+        result.coinsWithdrawalTx = { status: "skipped", txHash: null, message: "ETH balance is <= 0.001, transaction skipped" }
       }
     }
 

--- a/lib/blockchains/EthereumBlockchain.js
+++ b/lib/blockchains/EthereumBlockchain.js
@@ -243,26 +243,28 @@ class EthereumBlockchain {
   }
 
   async sendEIP1559Tx(txn, hotWallet) {
-    const web3 = new Web3(new Web3.providers.HttpProvider(`https://rinkeby.infura.io/v3/${this.envs.infuraProjectId}`))
+    const web3 = new Web3(new Web3.providers.HttpProvider(`https://ropsten.infura.io/v3/${this.envs.infuraProjectId}`))
 
     txn.gasLimit = await web3.eth.estimateGas(txn)
-    txn.maxPriorityFeePerGas = 1
-    txn.maxFeePerGas = 255
+    txn.maxPriorityFeePerGas = web3.utils.toHex(web3.utils.toWei( '2' , 'gwei' ))
+    txn.maxFeePerGas =  web3.utils.toHex(web3.utils.toWei( '3' , 'gwei' ))
     txn.nonce = await web3.eth.getTransactionCount(hotWallet.address, 'pending')
 
-    const common = new Common.default({ chain: Common.Chain.Rinkeby, hardfork: Common.Hardfork.London })
+    const common = new Common.default({ chain : 'ropsten', hardfork : 'london' })
     const tx = FeeMarketEIP1559Transaction.fromTxData(txn, { common })
     const signedTx = tx.sign(Buffer.from(hotWallet.privateKey.slice(2), 'hex'))
     const serializedTx = signedTx.serialize().toString('hex')
-    
+ 
     return await new Promise(async (resolve) => {
       await web3.eth.sendSignedTransaction('0x' + serializedTx)
         .once('transactionHash', txHash => {
           console.log('transactionHash:', txHash)
         })
-        .once('confirmation', (confirmationNumber, receipt) => {
-          console.log('confirmations:', confirmationNumber, receipt)
-          resolve({ transactionId: receipt.txHash })
+        .on('confirmation', (confirmationNumber, receipt) => {
+          console.log('confirmations:', receipt.transactionHash, confirmationNumber, receipt)
+          if (confirmationNumber > 1) {
+            resolve({ transactionId: receipt.transactionHash })
+          }
         })
         .once('error:', error => {
           console.error(error)

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "test": "jest -i"
   },
   "dependencies": {
+    "@ethereumjs/tx": "^3.3.1",
     "@open-rights-exchange/chainjs": "^0.28.6",
     "algosdk": "^1.8.1",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "dotenv": "^8.2.0",
     "pm2": "^4.5.1",
-    "redis": "^3.1.1"
+    "redis": "^3.1.1",
+    "web3": "^1.5.3"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,22 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ethereumjs/common@^2.3.0", "@ethereumjs/common@^2.4.0", "@ethereumjs/common@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.5.0.tgz#ec61551b31bef7a69d1dc634d8932468866a4268"
+  integrity sha512-DEHjW6e38o+JmB/NO3GZBpW4lpaiBpkFgXF6jLcJ6gETBYpEyaA5nTimsWBUJR3Vmtm/didUEbNjajskugZORg==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.1"
+
+"@ethereumjs/tx@^3.2.1", "@ethereumjs/tx@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.1.tgz#83b6b1f9fe8182d6f2a1d7bff8213631629ab8a4"
+  integrity sha512-DXcBdW4upjU11FGlGBAMJw4jXAveL1Siu/8t9jfJ90dehOmpCyGTGWXr6tFzN8663Et8UFLcw3IdV7JJt88iZw==
+  dependencies:
+    "@ethereumjs/common" "^2.5.0"
+    ethereumjs-util "^7.1.1"
+
 "@ethersproject/abi@5.0.7":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.7.tgz#79e52452bd3ca2956d0e1c964207a58ad1a0ee7b"
@@ -1042,6 +1058,13 @@
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
   dependencies:
     "@types/node" "*"
 
@@ -2125,6 +2148,14 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -2849,6 +2880,18 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.0:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.1.tgz#236ef435f46820f0c420a708c0559b5897952069"
+  integrity sha512-1CGBmCp3m8IMGHhAJF/icH8qjCJrfQtaZ9KW+cAVV8kyN5Lc1IRq3KjV77ILOutrCwiyf5y2gMyCrAUMoCf2Ag==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
+
 ethereumjs-wallet@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz#685e9091645cee230ad125c007658833991ed474"
@@ -2976,6 +3019,11 @@ execa@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 exit@^0.1.2:
   version "0.1.2"
@@ -5507,6 +5555,11 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -6944,6 +6997,15 @@ web3-bzz@1.3.4:
     swarm-js "^0.1.40"
     underscore "1.9.1"
 
+web3-bzz@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.5.3.tgz#e36456905ce051138f9c3ce3623cbc73da088c2b"
+  integrity sha512-SlIkAqG0eS6cBS9Q2eBOTI1XFzqh83RqGJWnyrNZMDxUwsTVHL+zNnaPShVPvrWQA1Ub5b0bx1Kc5+qJVxsTJg==
+  dependencies:
+    "@types/node" "^12.12.6"
+    got "9.6.0"
+    swarm-js "^0.1.40"
+
 web3-core-helpers@1.3.4, web3-core-helpers@^1.2.9:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.3.4.tgz#b8549740bf24d5c71688d89c3cdd802d8d36b4e4"
@@ -6952,6 +7014,14 @@ web3-core-helpers@1.3.4, web3-core-helpers@^1.2.9:
     underscore "1.9.1"
     web3-eth-iban "1.3.4"
     web3-utils "1.3.4"
+
+web3-core-helpers@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.5.3.tgz#099030235c477aadf39a94199ef40092151d563c"
+  integrity sha512-Ip1IjB3S8vN7Kf1PPjK41U5gskmMk6IJQlxIVuS8/1U7n/o0jC8krqtpRwiMfAgYyw3TXwBFtxSRTvJtnLyXZw==
+  dependencies:
+    web3-eth-iban "1.5.3"
+    web3-utils "1.5.3"
 
 web3-core-method@1.3.4:
   version "1.3.4"
@@ -6965,10 +7035,29 @@ web3-core-method@1.3.4:
     web3-core-subscriptions "1.3.4"
     web3-utils "1.3.4"
 
+web3-core-method@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.5.3.tgz#6cff97ed19fe4ea2e9183d6f703823a079f5132c"
+  integrity sha512-8wJrwQ2qD9ibWieF9oHXwrJsUGrv3XAtEkNeyvyNMpktNTIjxJ2jaFGQUuLiyUrMubD18XXgLk4JS6PJU4Loeg==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    "@ethersproject/transactions" "^5.0.0-beta.135"
+    web3-core-helpers "1.5.3"
+    web3-core-promievent "1.5.3"
+    web3-core-subscriptions "1.5.3"
+    web3-utils "1.5.3"
+
 web3-core-promievent@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.3.4.tgz#d166239012d91496cdcbe91d5d54071ea818bc73"
   integrity sha512-V61dZIeBwogg6hhZZUt0qL9hTp1WDhnsdjP++9fhTDr4vy/Gz8T5vibqT2LLg6lQC8i+Py33yOpMeMNjztaUaw==
+  dependencies:
+    eventemitter3 "4.0.4"
+
+web3-core-promievent@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.5.3.tgz#3f11833c3dc6495577c274350b61144e0a4dba01"
+  integrity sha512-CFfgqvk3Vk6PIAxtLLuX+pOMozxkKCY+/GdGr7weMh033mDXEPvwyVjoSRO1PqIKj668/hMGQsVoIgbyxkJ9Mg==
   dependencies:
     eventemitter3 "4.0.4"
 
@@ -6984,6 +7073,17 @@ web3-core-requestmanager@1.3.4:
     web3-providers-ipc "1.3.4"
     web3-providers-ws "1.3.4"
 
+web3-core-requestmanager@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.5.3.tgz#b339525815fd40e3a2a81813c864ddc413f7b6f7"
+  integrity sha512-9k/Bze2rs8ONix5IZR+hYdMNQv+ark2Ek2kVcrFgWO+LdLgZui/rn8FikPunjE+ub7x7pJaKCgVRbYFXjo3ZWg==
+  dependencies:
+    util "^0.12.0"
+    web3-core-helpers "1.5.3"
+    web3-providers-http "1.5.3"
+    web3-providers-ipc "1.5.3"
+    web3-providers-ws "1.5.3"
+
 web3-core-subscriptions@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4.tgz#7b00e92bde21f792620cd02e6e508fcf4f4c31d3"
@@ -6992,6 +7092,14 @@ web3-core-subscriptions@1.3.4:
     eventemitter3 "4.0.4"
     underscore "1.9.1"
     web3-core-helpers "1.3.4"
+
+web3-core-subscriptions@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.5.3.tgz#d7d69c4caad65074212028656e9dc56ca5c2159d"
+  integrity sha512-L2m9vG1iRN6thvmv/HQwO2YLhOQlmZU8dpLG6GSo9FBN14Uch868Swk0dYVr3rFSYjZ/GETevSXU+O+vhCummA==
+  dependencies:
+    eventemitter3 "4.0.4"
+    web3-core-helpers "1.5.3"
 
 web3-core@1.3.4:
   version "1.3.4"
@@ -7006,6 +7114,19 @@ web3-core@1.3.4:
     web3-core-requestmanager "1.3.4"
     web3-utils "1.3.4"
 
+web3-core@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.5.3.tgz#59f8728b27c8305b349051326aa262b9b7e907bf"
+  integrity sha512-ACTbu8COCu+0eUNmd9pG7Q9EVsNkAg2w3Y7SqhDr+zjTgbSHZV01jXKlapm9z+G3AN/BziV3zGwudClJ4u4xXQ==
+  dependencies:
+    "@types/bn.js" "^4.11.5"
+    "@types/node" "^12.12.6"
+    bignumber.js "^9.0.0"
+    web3-core-helpers "1.5.3"
+    web3-core-method "1.5.3"
+    web3-core-requestmanager "1.5.3"
+    web3-utils "1.5.3"
+
 web3-eth-abi@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.3.4.tgz#10f5d8b6080dbb6cbaa1bcef7e0c70573da6566f"
@@ -7014,6 +7135,14 @@ web3-eth-abi@1.3.4:
     "@ethersproject/abi" "5.0.7"
     underscore "1.9.1"
     web3-utils "1.3.4"
+
+web3-eth-abi@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.5.3.tgz#5aea9394d797f99ca0d9bd40c3417eb07241c96c"
+  integrity sha512-i/qhuFsoNrnV130CSRYX/z4SlCfSQ4mHntti5yTmmQpt70xZKYZ57BsU0R29ueSQ9/P+aQrL2t2rqkQkAloUxg==
+  dependencies:
+    "@ethersproject/abi" "5.0.7"
+    web3-utils "1.5.3"
 
 web3-eth-accounts@1.3.4:
   version "1.3.4"
@@ -7032,6 +7161,23 @@ web3-eth-accounts@1.3.4:
     web3-core-method "1.3.4"
     web3-utils "1.3.4"
 
+web3-eth-accounts@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.5.3.tgz#076c816ff4d68c9dffebdc7fd2bfaddcfc163d77"
+  integrity sha512-pdGhXgeBaEJENMvRT6W9cmji3Zz/46ugFSvmnLLw79qi5EH7XJhKISNVb41eWCrs4am5GhI67GLx5d2s2a72iw==
+  dependencies:
+    "@ethereumjs/common" "^2.3.0"
+    "@ethereumjs/tx" "^3.2.1"
+    crypto-browserify "3.12.0"
+    eth-lib "0.2.8"
+    ethereumjs-util "^7.0.10"
+    scrypt-js "^3.0.1"
+    uuid "3.3.2"
+    web3-core "1.5.3"
+    web3-core-helpers "1.5.3"
+    web3-core-method "1.5.3"
+    web3-utils "1.5.3"
+
 web3-eth-contract@1.3.4, web3-eth-contract@^1.2.9:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.3.4.tgz#1ea2dd71be0c4a9cf4772d4f75dbb2fa99751472"
@@ -7046,6 +7192,20 @@ web3-eth-contract@1.3.4, web3-eth-contract@^1.2.9:
     web3-core-subscriptions "1.3.4"
     web3-eth-abi "1.3.4"
     web3-utils "1.3.4"
+
+web3-eth-contract@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.5.3.tgz#12b03a4a16ce583a945f874bea2ff2fb4c5b81ad"
+  integrity sha512-Gdlt1L6cdHe83k7SdV6xhqCytVtOZkjD0kY/15x441AuuJ4JLubCHuqu69k2Dr3tWifHYVys/vG8QE/W16syGg==
+  dependencies:
+    "@types/bn.js" "^4.11.5"
+    web3-core "1.5.3"
+    web3-core-helpers "1.5.3"
+    web3-core-method "1.5.3"
+    web3-core-promievent "1.5.3"
+    web3-core-subscriptions "1.5.3"
+    web3-eth-abi "1.5.3"
+    web3-utils "1.5.3"
 
 web3-eth-ens@1.3.4:
   version "1.3.4"
@@ -7062,6 +7222,20 @@ web3-eth-ens@1.3.4:
     web3-eth-contract "1.3.4"
     web3-utils "1.3.4"
 
+web3-eth-ens@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.5.3.tgz#ef6eee1ddf32b1ff9536fc7c599a74f2656bafe1"
+  integrity sha512-QmGFFtTGElg0E+3xfCIFhiUF+1imFi9eg/cdsRMUZU4F1+MZCC/ee+IAelYLfNTGsEslCqfAusliKOT9DdGGnw==
+  dependencies:
+    content-hash "^2.5.2"
+    eth-ens-namehash "2.0.8"
+    web3-core "1.5.3"
+    web3-core-helpers "1.5.3"
+    web3-core-promievent "1.5.3"
+    web3-eth-abi "1.5.3"
+    web3-eth-contract "1.5.3"
+    web3-utils "1.5.3"
+
 web3-eth-iban@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.3.4.tgz#5eb7a564e0dcf68730d68f48f95dd207cd173d81"
@@ -7069,6 +7243,14 @@ web3-eth-iban@1.3.4:
   dependencies:
     bn.js "^4.11.9"
     web3-utils "1.3.4"
+
+web3-eth-iban@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.5.3.tgz#91b1475893a877b10eac1de5cce6eb379fb81b5d"
+  integrity sha512-vMzmGqolYZvRHwP9P4Nf6G8uYM5aTLlQu2a34vz78p0KlDC+eV1th3+90Qeaupa28EG7OO0IT1F0BejiIauOPw==
+  dependencies:
+    bn.js "^4.11.9"
+    web3-utils "1.5.3"
 
 web3-eth-personal@1.3.4:
   version "1.3.4"
@@ -7081,6 +7263,18 @@ web3-eth-personal@1.3.4:
     web3-core-method "1.3.4"
     web3-net "1.3.4"
     web3-utils "1.3.4"
+
+web3-eth-personal@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.5.3.tgz#4ebe09e9a77dd49d23d93b36b36cfbf4a6dae713"
+  integrity sha512-JzibJafR7ak/Icas8uvos3BmUNrZw1vShuNR5Cxjo+vteOC8XMqz1Vr7RH65B4bmlfb3bm9xLxetUHO894+Sew==
+  dependencies:
+    "@types/node" "^12.12.6"
+    web3-core "1.5.3"
+    web3-core-helpers "1.5.3"
+    web3-core-method "1.5.3"
+    web3-net "1.5.3"
+    web3-utils "1.5.3"
 
 web3-eth@1.3.4, web3-eth@^1.2.9:
   version "1.3.4"
@@ -7101,6 +7295,24 @@ web3-eth@1.3.4, web3-eth@^1.2.9:
     web3-net "1.3.4"
     web3-utils "1.3.4"
 
+web3-eth@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.5.3.tgz#d7d1ac7198f816ab8a2088c01e0bf1eda45862fe"
+  integrity sha512-saFurA1L23Bd7MEf7cBli6/jRdMhD4X/NaMiO2mdMMCXlPujoudlIJf+VWpRWJpsbDFdu7XJ2WHkmBYT5R3p1Q==
+  dependencies:
+    web3-core "1.5.3"
+    web3-core-helpers "1.5.3"
+    web3-core-method "1.5.3"
+    web3-core-subscriptions "1.5.3"
+    web3-eth-abi "1.5.3"
+    web3-eth-accounts "1.5.3"
+    web3-eth-contract "1.5.3"
+    web3-eth-ens "1.5.3"
+    web3-eth-iban "1.5.3"
+    web3-eth-personal "1.5.3"
+    web3-net "1.5.3"
+    web3-utils "1.5.3"
+
 web3-net@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.3.4.tgz#d76158bf0b4a7b3b14352b4f95472db9efc57a2a"
@@ -7110,12 +7322,29 @@ web3-net@1.3.4:
     web3-core-method "1.3.4"
     web3-utils "1.3.4"
 
+web3-net@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.5.3.tgz#545fee49b8e213b0c55cbe74ffd0295766057463"
+  integrity sha512-0W/xHIPvgVXPSdLu0iZYnpcrgNnhzHMC888uMlGP5+qMCt8VuflUZHy7tYXae9Mzsg1kxaJAS5lHVNyeNw4CoQ==
+  dependencies:
+    web3-core "1.5.3"
+    web3-core-method "1.5.3"
+    web3-utils "1.5.3"
+
 web3-providers-http@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.3.4.tgz#89389e18e27148faa2fef58842740ffadbdda8cc"
   integrity sha512-aIg/xHXvxpqpFU70sqfp+JC3sGkLfAimRKTUhG4oJZ7U+tTcYTHoxBJj+4A3Id4JAoKiiv0k1/qeyQ8f3rMC3g==
   dependencies:
     web3-core-helpers "1.3.4"
+    xhr2-cookies "1.1.0"
+
+web3-providers-http@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.5.3.tgz#74f170fc3d79eb7941d9fbc34e2a067d61ced0b2"
+  integrity sha512-5DpUyWGHtDAr2RYmBu34Fu+4gJuBAuNx2POeiJIooUtJ+Mu6pIx4XkONWH6V+Ez87tZAVAsFOkJRTYuzMr3rPw==
+  dependencies:
+    web3-core-helpers "1.5.3"
     xhr2-cookies "1.1.0"
 
 web3-providers-ipc@1.3.4:
@@ -7127,6 +7356,14 @@ web3-providers-ipc@1.3.4:
     underscore "1.9.1"
     web3-core-helpers "1.3.4"
 
+web3-providers-ipc@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.5.3.tgz#4bd7f5e445c2f3c2595fce0929c72bb879320a3f"
+  integrity sha512-JmeAptugVpmXI39LGxUSAymx0NOFdgpuI1hGQfIhbEAcd4sv7fhfd5D+ZU4oLHbRI8IFr4qfGU0uhR8BXhDzlg==
+  dependencies:
+    oboe "2.1.5"
+    web3-core-helpers "1.5.3"
+
 web3-providers-ws@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.3.4.tgz#b94c2e0ec51a0c472abdec53a472b5bf8176bec1"
@@ -7135,6 +7372,15 @@ web3-providers-ws@1.3.4:
     eventemitter3 "4.0.4"
     underscore "1.9.1"
     web3-core-helpers "1.3.4"
+    websocket "^1.0.32"
+
+web3-providers-ws@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.5.3.tgz#eec6cfb32bb928a4106de506f13a49070a21eabf"
+  integrity sha512-6DhTw4Q7nm5CFYEUHOJM0gAb3xFx+9gWpVveg3YxJ/ybR1BUvEWo3bLgIJJtX56cYX0WyY6DS35a7f0LOI1kVg==
+  dependencies:
+    eventemitter3 "4.0.4"
+    web3-core-helpers "1.5.3"
     websocket "^1.0.32"
 
 web3-shh@1.3.4:
@@ -7146,6 +7392,16 @@ web3-shh@1.3.4:
     web3-core-method "1.3.4"
     web3-core-subscriptions "1.3.4"
     web3-net "1.3.4"
+
+web3-shh@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.5.3.tgz#3c04aa4cda9ba0b746d7225262401160f8e38b13"
+  integrity sha512-COfEXfsqoV/BkcsNLRxQqnWc1Teb8/9GxdGag5GtPC5gQC/vsN+7hYVJUwNxY9LtJPKYTij2DHHnx6UkITng+Q==
+  dependencies:
+    web3-core "1.5.3"
+    web3-core-method "1.5.3"
+    web3-core-subscriptions "1.5.3"
+    web3-net "1.5.3"
 
 web3-utils@1.3.4:
   version "1.3.4"
@@ -7161,6 +7417,19 @@ web3-utils@1.3.4:
     underscore "1.9.1"
     utf8 "3.0.0"
 
+web3-utils@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.5.3.tgz#e914c9320cd663b2a09a5cb920ede574043eb437"
+  integrity sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==
+  dependencies:
+    bn.js "^4.11.9"
+    eth-lib "0.2.8"
+    ethereum-bloom-filters "^1.0.6"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
 web3@^1.2.9:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.3.4.tgz#31e014873360aa5840eb17f9f171190c967cffb7"
@@ -7173,6 +7442,19 @@ web3@^1.2.9:
     web3-net "1.3.4"
     web3-shh "1.3.4"
     web3-utils "1.3.4"
+
+web3@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-1.5.3.tgz#11882679453c645bf33620fbc255a243343075aa"
+  integrity sha512-eyBg/1K44flfv0hPjXfKvNwcUfIVDI4NX48qHQe6wd7C8nPSdbWqo9vLy6ksZIt9NLa90HjI8HsGYgnMSUxn6w==
+  dependencies:
+    web3-bzz "1.5.3"
+    web3-core "1.5.3"
+    web3-eth "1.5.3"
+    web3-eth-personal "1.5.3"
+    web3-net "1.5.3"
+    web3-shh "1.5.3"
+    web3-utils "1.5.3"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Add `EthereumBlockchain#sendEIP1559Tx`
- Update `approveContractTransactions` and `sendTransaction` to use the `EthereumBlockchain#sendEIP1559Tx`
- Remove `EthereumBlockchain#sendEIP1559Tx#sendWithdrawalCoinsTransaction`
- Switch `EthereumBlockchain#sendEIP1559Tx#disableWallet` to use `sendTransaction `
- Disable balance caching