### PR TITLE
Fix Algorand OptIn process

### DIFF
--- a/lib/blockchains/AlgorandBlockchain.js
+++ b/lib/blockchains/AlgorandBlockchain.js
@@ -222,11 +222,11 @@ class AlgorandBlockchain {
 
     // Check if the wallet has enough balance to send opt-in transaction
     if (await this.enoughCoinBalanceToSendTransaction(hotWallet.address)) {
-      tx_result = await this.optInToApp(hotWallet, appIndex)
+      const tx_result = await this.optInToApp(hotWallet, appIndex)
+
       if (this.isEmptyObject(tx_result)) {
         console.log(`Failed to opt-in into app ${appIndex} for wallet ${hotWallet.address}`)
         return false
-
       } else {
         console.log("HW successfully opted-in!")
         return true


### PR DESCRIPTION
https://comakery-upside.atlassian.net/browse/UPS-389

Even with the error it successfully send opt-in tx and it update opted-in apps from blockchain after auto-reload of the Robowallet.

It was just `const` missing, this PR fixes that. 
After the fix the error is gone.

```
Nov 02 03:02:56 robowallet-ast-1383 app/service.1 wallet already created, using it...
Nov 02 03:02:56 robowallet-ast-1383 app/service.1 The Hot Wallet either has zero algos balance or doesn't opted-in to any app. Please send ALGOs to the wallet H5SE7DAVOPOOQVCMVWTTYPWKK4CZB7NK6FTWGFDXKO2QIDK2XVSP4CBS5I
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 Opt-in was successfully sent to blockchain, tx hash: GPOPBBX27WTMGVVEFGRZWGCSJL3UT3EZSOEPADKDZV6UGRR2AP4Q
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 HW successfully opted-in!
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 The Hot Wallet either has zero algos balance or doesn't opted-in to any app. Please send ALGOs to the wallet H5SE7DAVOPOOQVCMVWTTYPWKK4CZB7NK6FTWGFDXKO2QIDK2XVSP4CBS5I
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 Opted-in apps ([]) has been saved into wallet_for_project_1383
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 The Hot Wallet does not have tokens. Please top up the H5SE7DAVOPOOQVCMVWTTYPWKK4CZB7NK6FTWGFDXKO2QIDK2XVSP4CBS5I
Nov 02 03:03:09 robowallet-ast-1383 app/service.1 waiting 30 seconds
Nov 02 03:03:39 robowallet-ast-1383 app/service.1 HW is already opted-in. Got from Blockchain
Nov 02 03:03:39 robowallet-ast-1383 app/service.1 Opted-in apps ([13997710]) has been saved into wallet_for_project_1383
Nov 02 03:03:39 robowallet-ast-1383 app/service.1 The Hot Wallet does not have tokens. Please top up the H5SE7DAVOPOOQVCMVWTTYPWKK4CZB7NK6FTWGFDXKO2QIDK2XVSP4CBS5I
Nov 02 03:03:39 robowallet-ast-1383 app/service.1 waiting 30 seconds
```