### PR TITLE
UPS-526 Remove hot wallet token balance check before API calls.

### DIFF
--- a/lib/hotwalletUtils.js
+++ b/lib/hotwalletUtils.js
@@ -117,12 +117,6 @@ exports.waitForNewTransaction = async function waitForNewTransaction(envs, hwRed
     }
   }
 
-  const hasTokens = await blockchain.positiveTokenBalance(hwAddress)
-  if (!hasTokens) {
-    console.log(`The Hot Wallet does not have tokens. Please top up the ${hwAddress}`)
-    return { status: "failed_before_getting_tx", blockchainTransaction: {}, transaction: {} }
-  }
-
   console.log(`Checking for a new transaction to send from ${hwAddress}`)
   const hwApi = new ComakeryApi(envs)
   const blockchainTransaction = await hwApi.getNextTransactionToSign(hwAddress)

--- a/tests/waitForNewTransaction.test.js
+++ b/tests/waitForNewTransaction.test.js
@@ -43,7 +43,7 @@ describe("For Ethereum blockchain", () => {
 
     const res = await hwUtils.waitForNewTransaction(envs, hwRedis)
 
-    expect(res).toEqual({"blockchainTransaction": {}, "status": "failed_before_getting_tx", "transaction": {}})
+    expect(res).toEqual({"blockchainTransaction": {}, "status": "validation_failed", "transaction": {}})
   })
 
   test("API returns empty response", async () => {


### PR DESCRIPTION
Removing because we were essentially checking for the balance twice – before and after getting the tx from backend.
The first check is not necessary, and complicates the withdrawals.

In case of isnufficient tokens an error would be returned to backend and transaction would be returned back to the queue immidiately.