### PR TITLE
fix: requires equal address for SPL transfer

### DIFF
--- a/lib/validators/SolanaTxValidator.js
+++ b/lib/validators/SolanaTxValidator.js
@@ -185,16 +185,11 @@ class SolanaTxValidator {
           return { valid: false, markAs: "cancelled", error: errorMessage, switchHWToManualMode: true }
       }
       // Token transfers (SPL or contracts)
-      if (blockchainTransaction.contractAddress != txn.tokenMintAddress) {
-        const errorMessage = `The Robo Wallet requires equal address for SPL transfers. Please check ${blockchainTransaction.contractAddress}, ${txn.tokenMintAddress}`
-        console.log(errorMessage)
-        return { valid: false, markAs: "cancelled", error: errorMessage, switchHWToManualMode: true }
-      }
       const amountInBaseUnit = new BigNumber(blockchainTransaction.amount)
 
       // validate enough tokens
       if (amountInBaseUnit.isGreaterThan(new BigNumber(0))) {
-        const tokenBalance = await this.blockchain.getTokenBalance(hotWalletAddress, blockchainTransaction.contractAddress) // is it possible that contractAddress != tx.mintAddress
+        const tokenBalance = await this.blockchain.getTokenBalance(hotWalletAddress, txn.tokenMintAddress)
 
         if (tokenBalance.balanceInBaseUnit.isLessThan(amountInBaseUnit)) {
           const errorMessage = `The Robo Wallet has insufficient tokens. Please top up the ${hotWalletAddress}`

--- a/tests/SolanaTxValidator.isTransactionValid.test.js
+++ b/tests/SolanaTxValidator.isTransactionValid.test.js
@@ -95,18 +95,6 @@ describe("SolanaBlockchain.isTransactionValid", () => {
       expect(validResults.switchHWToManualMode).toBe(true)
     })
 
-    test('for different contract address and token mint adress', async () => {
-      const contractAddress = SplblockchainTransaction.contractAddress
-      SplblockchainTransaction.contractAddress = 'BP225Qq7uxbaXybXkicUehkfeKkk6a1JcFwcX4Laem1t'
-      const validResults = await solanaTxValidator.isTransactionValid(SplblockchainTransaction, hwAddress)
-      expect(validResults.valid).toBe(false)
-      expect(validResults.markAs).toBe("cancelled")
-      expect(validResults.error).toEqual(`The Robo Wallet requires equal address for SPL transfers. Please check ${SplblockchainTransaction.contractAddress}, ${SplTxRaw.tokenMintAddress}`)
-      expect(validResults.switchHWToManualMode).toBe(true)
-      SplblockchainTransaction.contractAddress = contractAddress
-
-    })
-
     test('for different ammounts', async () => {
       const amount = SplblockchainTransaction.amount
       SplblockchainTransaction.amount = 100


### PR DESCRIPTION
`contractAddress` is Solana Account which holding data
`tokenMintAddress` is Solana SPL Token